### PR TITLE
GoogleCloud wagon throw NPE because of keyPath is null

### DIFF
--- a/GoogleStorageWagon/src/main/java/com/gkatzioura/maven/cloud/gcs/wagon/GoogleStorageWagon.java
+++ b/GoogleStorageWagon/src/main/java/com/gkatzioura/maven/cloud/gcs/wagon/GoogleStorageWagon.java
@@ -45,7 +45,7 @@ import com.gkatzioura.maven.cloud.wagon.PublicReadProperty;
 public class GoogleStorageWagon extends AbstractStorageWagon {
 
     private GoogleStorageRepository googleStorageRepository;
-    private Optional<String> keyPath;
+    private Optional<String> keyPath = Optional.empty();
     private Boolean publicRepository;
 
     private static final Logger LOGGER = Logger.getLogger(GoogleStorageWagon.class.getName());


### PR DESCRIPTION
I am getting below error when I try to use version 2.3. I did little bit debugging and looks like keypath is not set by anyone and it does not have initial value. I assumed it is lack of implementation. I set initial value for it. It solved my issue. In addition to my pr. Looks like some one create another pr that facing some issue #75 
Please review my pr @gkatzioura 

```java
SEVERE: Could not establish connection with google cloud
java.lang.NullPointerException
	at com.gkatzioura.maven.cloud.gcs.wagon.GoogleStorageRepository.createStorage(GoogleStorageRepository.java:74)
	at com.gkatzioura.maven.cloud.gcs.wagon.GoogleStorageRepository.connect(GoogleStorageRepository.java:65)
	at com.gkatzioura.maven.cloud.gcs.wagon.GoogleStorageWagon.connect(GoogleStorageWagon.java:139)
	at org.eclipse.aether.transport.wagon.WagonTransporter.connectWagon(WagonTransporter.java:342)
	at org.eclipse.aether.transport.wagon.WagonTransporter.pollWagon(WagonTransporter.java:382)
	at org.eclipse.aether.transport.wagon.WagonTransporter.execute(WagonTransporter.java:431)
	at org.eclipse.aether.transport.wagon.WagonTransporter.get(WagonTransporter.java:412)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$GetTaskRunner.runTask(BasicRepositoryConnector.java:456)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run(BasicRepositoryConnector.java:363)
	at org.eclipse.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:75)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector$DirectExecutor.execute(BasicRepositoryConnector.java:642)
	at org.eclipse.aether.connector.basic.BasicRepositoryConnector.get(BasicRepositoryConnector.java:235)
	at org.eclipse.aether.internal.impl.DefaultDeployer.upload(DefaultDeployer.java:401)
	at org.eclipse.aether.internal.impl.DefaultDeployer.deploy(DefaultDeployer.java:258)
	at org.eclipse.aether.internal.impl.DefaultDeployer.deploy(DefaultDeployer.java:211)
	at org.eclipse.aether.internal.impl.DefaultRepositorySystem.deploy(DefaultRepositorySystem.java:381)
	at org.apache.maven.artifact.deployer.DefaultArtifactDeployer.deploy(DefaultArtifactDeployer.java:142)
	at org.apache.maven.plugin.deploy.AbstractDeployMojo.deploy(AbstractDeployMojo.java:171)
	at org.apache.maven.plugin.deploy.DeployMojo.deployProject(DeployMojo.java:242)
	at org.apache.maven.plugin.deploy.DeployMojo.execute(DeployMojo.java:169)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:137)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:210)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:156)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:148)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:117)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:81)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:56)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:305)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:192)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:105)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:956)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:288)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:192)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:282)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:225)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:406)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:347)
```