### PR TITLE
Report actual read count instead of buffer size during transfer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+jdk: openjdk8
 
 services:
   - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,7 @@ before_install:
 - docker pull maven
 
 script:
-- mvn clean install -Dgpg.skip=true
+# As noted at https://docs.travis-ci.com/user/languages/java/#projects-using-maven
+# Travis always runs mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+# The following line runs if that succeeds
+- mvn clean install

--- a/CloudStorageCore/src/main/java/com/gkatzioura/maven/cloud/transfer/TransferProgressFileInputStream.java
+++ b/CloudStorageCore/src/main/java/com/gkatzioura/maven/cloud/transfer/TransferProgressFileInputStream.java
@@ -24,25 +24,10 @@ import java.io.IOException;
 public final class TransferProgressFileInputStream extends FileInputStream {
 
     private final TransferProgress transferProgress;
-    private long byteLeft;
-
-
-
 
     public TransferProgressFileInputStream(File file, TransferProgress transferProgress) throws IOException{
         super(file);
         this.transferProgress = transferProgress;
-        resetByteLeft();
-    }
-
-    private void resetByteLeft() throws IOException {
-        byteLeft = this.getChannel().size();
-    }
-
-    @Override
-    public synchronized void reset() throws IOException {
-        super.reset();
-        resetByteLeft();
     }
 
     @Override
@@ -50,7 +35,6 @@ public final class TransferProgressFileInputStream extends FileInputStream {
         int b = super.read();
         if(b != -1){
             this.transferProgress.progress(new byte[]{(byte) b}, 1);
-            byteLeft--;
         }//else we try to read but it was the end of the stream so nothing to report
         return b;
     }
@@ -58,37 +42,29 @@ public final class TransferProgressFileInputStream extends FileInputStream {
     @Override
     public int read(byte b[]) throws IOException {
         int count = super.read(b);
-        if (count != -1) {
-            this.transferProgress.progress(b, b.length);
-            byteLeft -= b.length;
-        }else{//end of the stream
-            this.transferProgress.progress(b, Math.toIntExact(byteLeft));
+        if (count < 1) {
+            return count;
         }
+
+        this.transferProgress.progress(b, count);
         return count;
     }
 
     @Override
     public int read(byte b[], int off, int len) throws IOException {
         int count = super.read(b, off, len);
-        if (off == 0) {
-            if (count != -1) {
-                this.transferProgress.progress(b, count);
-                byteLeft -= count;
-            }else{//end of the stream
-                this.transferProgress.progress(b, Math.toIntExact(byteLeft));
-            }
-        } else {
-            if (count != -1) {
-                byte[] bytes = new byte[count];
-                System.arraycopy(b, off, bytes, 0, count);
-                this.transferProgress.progress(bytes, len);
-                byteLeft -= count;
-            }else{//end of the stream
-                byte[] bytes = new byte[Math.toIntExact(byteLeft)];
-                System.arraycopy(b, off, bytes, 0, Math.toIntExact(byteLeft));
-                this.transferProgress.progress(b, Math.toIntExact(byteLeft));
-            }
+        if (count < 1) {
+            return count;
         }
+
+        if(off == 0) {
+            this.transferProgress.progress(b, count);
+        } else {
+            byte[] bytes = new byte[count];
+            System.arraycopy(b, off, bytes, 0, count);
+            this.transferProgress.progress(bytes, count);
+        }
+
         return count;
     }
 }

--- a/S3StorageWagon/pom.xml
+++ b/S3StorageWagon/pom.xml
@@ -121,6 +121,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-surefire-plugin</artifactId>
+                        <version>3.0.0-M5</version>
                         <configuration>
                             <!-- Tests that require an S3 setup with creadentials-->
                             <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.2.0</version>
+                <configuration>
+                    <source>8</source>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -84,6 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -100,7 +102,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>deploy</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>
@@ -116,6 +118,11 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <releaseProfiles>releases</releaseProfiles>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
During large uploads to an Azure Blob Container I received errors like:

`
[WARNING] Encountered issue during deployment: Failed to deploy artifacts: Could not transfer artifact blahblah from/to repo-id (bs://blob-artifacts/libs-snapshot/): IndexOutOfBoundsException
`

Running Maven with debug logging showed several warnings:

`
[DEBUG] Failed to dispatch transfer event 'PUT PROGRESSED bs://blob-artifacts/libs-snapshot/blah/blahblah/1.0.0-SNAPSHOT/blahblah-1.0.0-20210207.042725-1.pom <> C:\Java\blahblah\pom.xml' to org.apache.maven.cli.transfer.ConsoleMavenTransferListener
java.lang.IllegalArgumentException: progressed file size cannot be greater than size: 10054 > 5027
    at org.apache.commons.lang3.Validate.isTrue (Validate.java:158)
    at org.apache.maven.cli.transfer.AbstractMavenTransferListener$FileSizeFormat.formatProgress (AbstractMavenTransferListener.java:195)
    at org.apache.maven.cli.transfer.ConsoleMavenTransferListener.getStatus (ConsoleMavenTransferListener.java:117)
    at org.apache.maven.cli.transfer.ConsoleMavenTransferListener.transferProgressed (ConsoleMavenTransferListener.java:90)
    at org.eclipse.aether.internal.impl.SafeTransferListener.transferProgressed (SafeTransferListener.java:105)
    at org.eclipse.aether.connector.basic.TransferTransportListener.transportProgressed (TransferTransportListener.java:95)
    at org.eclipse.aether.transport.wagon.WagonTransferListener.transferProgress (WagonTransferListener.java:64)
    at com.gkatzioura.maven.cloud.listener.TransferListenerContainerImpl.lambda$fireTransferProgress$2 (TransferListenerContainerImpl.java:75)
    at java.util.Vector.forEach (Vector.java:1275)
    at com.gkatzioura.maven.cloud.listener.TransferListenerContainerImpl.fireTransferProgress (TransferListenerContainerImpl.java:75)
    at com.gkatzioura.maven.cloud.transfer.TransferProgressImpl.progress (TransferProgressImpl.java:36)
    at com.gkatzioura.maven.cloud.transfer.TransferProgressFileInputStream.read (TransferProgressFileInputStream.java:75)
    at java.io.FilterInputStream.read (FilterInputStream.java:133)
    at com.microsoft.azure.storage.core.Utility.writeToOutputStream (Utility.java:1364)
    at com.microsoft.azure.storage.core.Utility.writeToOutputStream (Utility.java:1293)
    at com.microsoft.azure.storage.core.Utility.writeToOutputStream (Utility.java:1257)
    at com.microsoft.azure.storage.core.ExecutionEngine.executeWithRetry (ExecutionEngine.java:99)
    at com.microsoft.azure.storage.blob.CloudBlockBlob.uploadFullBlob (CloudBlockBlob.java:892)
    at com.microsoft.azure.storage.blob.CloudBlockBlob.upload (CloudBlockBlob.java:722)
    at com.microsoft.azure.storage.blob.CloudBlockBlob.upload (CloudBlockBlob.java:601)
    at com.gkatzioura.maven.cloud.abs.AzureStorageRepository.put (AzureStorageRepository.java:123)
    at com.gkatzioura.maven.cloud.abs.AzureStorageWagon.put (AzureStorageWagon.java:95)
    at org.eclipse.aether.transport.wagon.WagonTransporter$PutTaskRunner.run (WagonTransporter.java:686)
    at org.eclipse.aether.transport.wagon.WagonTransporter.execute (WagonTransporter.java:435)
    at org.eclipse.aether.transport.wagon.WagonTransporter.put (WagonTransporter.java:418)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$PutTaskRunner.runTask (BasicRepositoryConnector.java:554)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run (BasicRepositoryConnector.java:363)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector.put (BasicRepositoryConnector.java:287)
    at org.eclipse.aether.internal.impl.DefaultDeployer.deploy (DefaultDeployer.java:295)
    at org.eclipse.aether.internal.impl.DefaultDeployer.deploy (DefaultDeployer.java:211)
    at org.eclipse.aether.internal.impl.DefaultRepositorySystem.deploy (DefaultRepositorySystem.java:371)
    at org.apache.maven.shared.transfer.artifact.deploy.internal.Maven31ArtifactDeployer.deploy (Maven31ArtifactDeployer.java:122)
    at org.apache.maven.shared.transfer.artifact.deploy.internal.DefaultArtifactDeployer.deploy (DefaultArtifactDeployer.java:79)
    at org.apache.maven.shared.transfer.project.deploy.internal.DefaultProjectDeployer.deploy (DefaultProjectDeployer.java:190)
    at org.apache.maven.shared.transfer.project.deploy.internal.DefaultProjectDeployer.deploy (DefaultProjectDeployer.java:134)
    at org.apache.maven.plugins.deploy.DeployMojo.deployProject (DeployMojo.java:193)
    at org.apache.maven.plugins.deploy.DeployMojo.execute (DeployMojo.java:177)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
`

The reported `IndexOutOfBoundsException` appeared to happen during a subsequent attempt to use the byte buffer with an incorrect length:

`
java.lang.IndexOutOfBoundsException
    at java.nio.ByteBuffer.wrap (ByteBuffer.java:375)
    at org.eclipse.aether.transport.wagon.WagonTransferListener.transferProgress (WagonTransferListener.java:64)
    at com.gkatzioura.maven.cloud.listener.TransferListenerContainerImpl.lambda$fireTransferProgress$2 (TransferListenerContainerImpl.java:75)
    at java.util.Vector.forEach (Vector.java:1275)
    at com.gkatzioura.maven.cloud.listener.TransferListenerContainerImpl.fireTransferProgress (TransferListenerContainerImpl.java:75)
    at com.gkatzioura.maven.cloud.transfer.TransferProgressImpl.progress (TransferProgressImpl.java:36)
    at com.gkatzioura.maven.cloud.transfer.TransferProgressFileInputStream.read (TransferProgressFileInputStream.java:78)
    at java.io.FilterInputStream.read (FilterInputStream.java:133)
    at com.microsoft.azure.storage.core.Utility.writeToOutputStream (Utility.java:1392)
    at com.microsoft.azure.storage.core.Utility.writeToOutputStream (Utility.java:1293)
    at com.microsoft.azure.storage.blob.BlobOutputStreamInternal.write (BlobOutputStreamInternal.java:663)
    at com.microsoft.azure.storage.blob.CloudBlockBlob.upload (CloudBlockBlob.java:754)
    at com.microsoft.azure.storage.blob.CloudBlockBlob.upload (CloudBlockBlob.java:601)
    at com.gkatzioura.maven.cloud.abs.AzureStorageRepository.put (AzureStorageRepository.java:123)
    at com.gkatzioura.maven.cloud.abs.AzureStorageWagon.put (AzureStorageWagon.java:95)
    at org.eclipse.aether.transport.wagon.WagonTransporter$PutTaskRunner.run (WagonTransporter.java:686)
    at org.eclipse.aether.transport.wagon.WagonTransporter.execute (WagonTransporter.java:435)
    at org.eclipse.aether.transport.wagon.WagonTransporter.put (WagonTransporter.java:418)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$PutTaskRunner.runTask (BasicRepositoryConnector.java:554)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector$TaskRunner.run (BasicRepositoryConnector.java:363)
    at org.eclipse.aether.connector.basic.BasicRepositoryConnector.put (BasicRepositoryConnector.java:287)
    at org.eclipse.aether.internal.impl.DefaultDeployer.deploy (DefaultDeployer.java:295)
    at org.eclipse.aether.internal.impl.DefaultDeployer.deploy (DefaultDeployer.java:211)
    at org.eclipse.aether.internal.impl.DefaultRepositorySystem.deploy (DefaultRepositorySystem.java:371)
    at org.apache.maven.shared.transfer.artifact.deploy.internal.Maven31ArtifactDeployer.deploy (Maven31ArtifactDeployer.java:122)
    at org.apache.maven.shared.transfer.artifact.deploy.internal.DefaultArtifactDeployer.deploy (DefaultArtifactDeployer.java:79)
    at org.apache.maven.shared.transfer.project.deploy.internal.DefaultProjectDeployer.deploy (DefaultProjectDeployer.java:190)
    at org.apache.maven.shared.transfer.project.deploy.internal.DefaultProjectDeployer.deploy (DefaultProjectDeployer.java:134)
    at org.apache.maven.plugins.deploy.DeployMojo.deployProject (DeployMojo.java:193)
    at org.apache.maven.plugins.deploy.DeployMojo.execute (DeployMojo.java:177)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:210)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:156)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:148)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:117)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:128)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:305)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:956)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:288)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:192)
    at sun.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:498)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:356)
`

This appears to relate to misreporting of the buffer size length in `TransferProgressFileInputStream`: the code assumed that every call to read would completely fill the requested length, rather than checking and reporting the byte count returned from `super.read()`. This PR fixes these issues by checking the returned bytes read. I expect this fixes #50.